### PR TITLE
refactor: Replace ModalContext with useModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "crypto-dashboard",
+  "name": "coin-watcher",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "crypto-dashboard",
+      "name": "coin-watcher",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "axios": "^0.24.0",
         "react": "^17.0.2",
@@ -1722,9 +1723,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -3737,9 +3738,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "description": "Check crypto prices and news.",
-	"license": "MIT",
+  "license": "MIT",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,30 @@
 import React, { useContext } from "react";
 import Header from "./components/Header";
+import DropdownMenu from "./components/Header/DropdownMenu";
+import NavBar from "./components/Header/NavBar";
 import CryptoList from "./components/CryptoList";
 import CryptoNews from "./components/CryptoNews";
-import CoinDetails from "./components/CoinDetails"
+import CoinDetails from "./components/CoinDetails";
 import Footer from "./components/Footer";
 import Modal from "./components/Modal";
 import { ThemeContext } from "./contexts/ThemeContext";
-import { ModalContext } from "./contexts/ModalContext";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, Link } from "react-router-dom";
+import useModal from "./hooks/useModal";
 
 const App = () => {
   const { darkMode } = useContext(ThemeContext);
-  const { isOpen } = useContext(ModalContext);
+  const { isOpen, modalRef, toggleModal, modalContent } = useModal();
 
   return (
     <main className={`relative ${darkMode ? "dark" : null}`}>
       <div className="flex min-h-screen flex-col justify-between bg-gradient-to-b from-cyan-100 to-cyan-50 font-medium dark:from-slate-800 dark:to-slate-700 dark:text-white">
-        <Header />
+        <Header>
+          <Link className="hidden w-min text-lg font-bold sm:block" to="/">
+            Coin Watcher
+          </Link>
+          <NavBar />
+          <DropdownMenu toggleModal={toggleModal} />
+        </Header>
         <Routes>
           <Route path="/" element={<CryptoList />} />
           <Route path="/news" element={<CryptoNews />} />
@@ -25,7 +33,13 @@ const App = () => {
         <Footer />
       </div>
 
-      {isOpen ? <Modal /> : null}
+      {isOpen ? (
+        <Modal
+          modalRef={modalRef}
+          toggleModal={toggleModal}
+          modalContent={modalContent}
+        />
+      ) : null}
     </main>
   );
 };

--- a/src/components/Header/DropdownMenu.jsx
+++ b/src/components/Header/DropdownMenu.jsx
@@ -9,12 +9,10 @@ import {
 } from "react-icons/fi";
 import { AiOutlineGithub } from "react-icons/ai";
 import { ThemeContext } from "../../contexts/ThemeContext";
-import { ModalContext } from "../../contexts/ModalContext";
 
-const DropdownMenu = () => {
+const DropdownMenu = ({ toggleModal }) => {
   const [displayMenu, menuRef, toggleMenu] = useToggleMenu();
   const { darkMode, toggleDarkMode } = useContext(ThemeContext);
-  const { toggleModal } = useContext(ModalContext);
 
   return (
     <div ref={menuRef} className="relative justify-self-end">

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,15 +1,9 @@
 import React from "react";
-import DropdownMenu from "./DropdownMenu";
-import NavBar from "./NavBar";
 
-const Header = () => {
+const Header = ({ children }) => {
   return (
     <header className="grid grid-cols-2 items-center justify-between p-5 sm:grid-cols-3">
-      <a className="hidden w-min text-lg font-bold sm:block" href="/">
-        Coin Watcher
-      </a>
-      <NavBar />
-      <DropdownMenu />
+      {children}
     </header>
   );
 };

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -1,12 +1,9 @@
-import React, { useContext } from "react";
-import { ModalContext } from "../../contexts/ModalContext";
+import React from "react";
 import { FiX } from "react-icons/fi";
 import coingeckoLogo from "../../assets/CoinGeckoLogo.png";
 import messariLogo from "../../assets/MessariLogo.svg";
 
-const Modal = () => {
-  const { modalRef, toggleModal, modalContent } = useContext(ModalContext);
-
+const Modal = ({ modalRef, toggleModal, modalContent }) => {
   return (
     <div className="fixed top-0 flex min-h-screen min-w-full items-center justify-center backdrop-brightness-50 dark:text-white">
       <div
@@ -33,8 +30,7 @@ const About = () => {
   return (
     <>
       <p className="text-xl">
-        Coin Watcher is a web application that displays crypto prices and
-        news.
+        Coin Watcher is a web application that displays crypto prices and news.
       </p>
       <p>The app uses the following third-party APIs:</p>
       <div className="flex flex-col gap-2 rounded-2xl bg-stone-100 p-4 dark:bg-zinc-800">

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -1,8 +1,6 @@
-import { createContext, useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 
-export const ModalContext = createContext({});
-
-export const ModalProvider = (props) => {
+const useModal = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [modalContent, setModalContent] = useState();
 
@@ -23,10 +21,7 @@ export const ModalProvider = (props) => {
     return () => document.removeEventListener("mousedown", handler);
   }, []);
 
-  return (
-    <ModalContext.Provider
-      value={{ isOpen, modalRef, toggleModal, modalContent }}
-      {...props}
-    />
-  );
+  return { isOpen, modalRef, toggleModal, modalContent };
 };
+
+export default useModal;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,16 +3,13 @@ import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
 import { ThemeProvider } from "./contexts/ThemeContext";
-import { ModalProvider } from "./contexts/ModalContext";
 import { BrowserRouter } from "react-router-dom";
 
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
       <ThemeProvider>
-        <ModalProvider>
-          <App />
-        </ModalProvider>
+        <App />
       </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>,


### PR DESCRIPTION
I'm getting rid of the `ModalContext`. This context was implemented in order to avoid prop drilling. I found out that composition is a much better solution so I'm using it on the `Header` component.